### PR TITLE
Asset package cache

### DIFF
--- a/Repository/Cache/AbstractAssetsRepositoryCache.php
+++ b/Repository/Cache/AbstractAssetsRepositoryCache.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * This file is part of the Fxp Composer Asset Plugin package.
+ *
+ * (c) François Pluchino <francois.pluchino@gmail.com>
+ * (c) Danil Syromolotov <pelmennoteam@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Fxp\Composer\AssetPlugin\Repository\Cache;
+
+/**
+ * Class AbstractAssetsRepositoryCache.
+ */
+abstract class AbstractAssetsRepositoryCache
+{
+    /**
+     * @var self[] list of registered cache objects
+     */
+    private static $_cacheList = array();
+
+    /**
+     * @return self[] returns a list of registered cache objects
+     */
+    public static function getCacheList()
+    {
+        return self::$_cacheList;
+    }
+
+    /**
+     * @return bool
+     */
+    final public static function cleanRegistration()
+    {
+        $className = get_called_class();
+        if ($className == __CLASS__) {
+            self::$_cacheList = array();
+
+            return true;
+        } elseif (isset(self::$_cacheList[$className])) {
+            unset(self::$_cacheList[$className]);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    public function __construct()
+    {
+        $this->register();
+    }
+
+    /**
+     * @param string $packageName          package name
+     * @param string $assetsRepositoryType bower or npm
+     *
+     * @return null|array list of items. Each item must be an associative array, which contains next elements:
+     *                    - version => '1.1.1.0'
+     *                    - dist => array('type' => 'zip', 'url' => 'path/to/archive.zip')
+     */
+    abstract public function findItems($packageName, $assetsRepositoryType);
+
+    /**
+     * register cache object in cache list.
+     */
+    protected function register()
+    {
+        $className = get_class($this);
+        self::$_cacheList[$className] = $this;
+    }
+
+    /**
+     * @return bool unregister cache object in cache list
+     */
+    public function unRegister()
+    {
+        $className = get_class($this);
+        if (isset(self::$_cacheList[$className])) {
+            unset(self::$_cacheList[$className]);
+
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -405,3 +405,33 @@ option `extra.asset-registry-options.{type}-searchable` in the root project
     }
 }
 ```
+
+### Assets cache
+
+Now plugin supports the cache system. You can write own cache-composer-plugin,
+for that you need to create own composer plugin and implement abstract method
+`AbstractAssetsRepositoryCache::findItems`
+
+```php
+class MyCachePlugin extends AbstractAssetsRepositoryCache
+{
+    public function findItems($packageName, $assetsRepositoryType)
+    {
+        ...
+    }
+}
+```
+
+Then register cache system through the creation of an object, e.g.
+
+```php
+class MyCacheComposerPlugin implements PluginInterface
+{
+    public function activate(Composer $composer, IOInterface $io)
+    {
+        new MyCachePlugin();
+    }
+}
+```
+
+(Plugin example: https://github.com/pelmennoteam/composer-asset-plugin-assagist)

--- a/Tests/Fixtures/Repository/Cache/MockAssetRepositoryCache.php
+++ b/Tests/Fixtures/Repository/Cache/MockAssetRepositoryCache.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * This file is part of the Fxp Composer Asset Plugin package.
+ *
+ * (c) François Pluchino <francois.pluchino@gmail.com>
+ * (c) Danil Syromolotov <pelmennoteam@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Fxp\Composer\AssetPlugin\Tests\Fixtures\Repository\Cache;
+
+use Fxp\Composer\AssetPlugin\Repository\AbstractAssetsRepository;
+use Fxp\Composer\AssetPlugin\Repository\Cache\AbstractAssetsRepositoryCache;
+
+/**
+ * Class MockAssetRepositoryCache.
+ */
+class MockAssetRepositoryCache extends AbstractAssetsRepositoryCache
+{
+    /**
+     * @var array
+     */
+    public $options = array();
+
+    /**
+     * MockAssetRepositoryCache constructor.
+     *
+     * @param array $options
+     */
+    public function __construct($options = array())
+    {
+        $this->options = $options;
+        parent::__construct();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findItems($packageName, $assetsRepositoryType)
+    {
+        if (preg_match('/^'.$assetsRepositoryType.'-asset\/existing/uis', $packageName)) {
+            return array(
+                array(
+                    'version' => '1.1.1.0',
+                    'dist' => array(
+                        'url' => '/path/to/not-existing/archive-1.1.1.0.zip',
+                        'type' => 'zip',
+                    ),
+                ),
+            );
+        }
+
+        return array();
+    }
+}

--- a/Tests/Repository/Cache/AbstractAssetsRepositoryCacheTest.php
+++ b/Tests/Repository/Cache/AbstractAssetsRepositoryCacheTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * This file is part of the Fxp Composer Asset Plugin package.
+ *
+ * (c) François Pluchino <francois.pluchino@gmail.com>
+ * (c) Danil Syromolotov <pelmennoteam@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Fxp\Composer\AssetPlugin\Tests\Repository\Cache;
+
+use Fxp\Composer\AssetPlugin\Repository\Cache\AbstractAssetsRepositoryCache;
+use Fxp\Composer\AssetPlugin\Tests\Fixtures\Repository\Cache\MockAssetRepositoryCache;
+
+/**
+ * Class AbstractAssetsRepositoryCacheTest.
+ */
+class AbstractAssetsRepositoryCacheTest extends \PHPUnit_Framework_TestCase
+{
+    public function testStaticListItems()
+    {
+        $cacheList = AbstractAssetsRepositoryCache::getCacheList();
+        $this->assertCount(0, $cacheList);
+
+        $cacheInstance = new MockAssetRepositoryCache(array(
+            'test' => 'option',
+        ));
+
+        $this->assertInstanceOf(
+            'Fxp\Composer\AssetPlugin\Repository\Cache\AbstractAssetsRepositoryCache',
+            $cacheInstance
+        );
+
+        $this->assertObjectHasAttribute('options', $cacheInstance);
+        $this->assertArrayHasKey('test', $cacheInstance->options);
+        $this->assertEquals('option', $cacheInstance->options['test']);
+
+        $cacheList = AbstractAssetsRepositoryCache::getCacheList();
+        $this->assertCount(1, $cacheList);
+
+        $this->assertEquals(true, $cacheInstance->unRegister());
+
+        $this->assertEquals(true, AbstractAssetsRepositoryCache::cleanRegistration());
+
+        $cacheList = AbstractAssetsRepositoryCache::getCacheList();
+        $this->assertCount(0, $cacheList);
+
+        $this->assertEquals(false, $cacheInstance->unRegister());
+
+        $this->assertEquals(false, MockAssetRepositoryCache::cleanRegistration());
+    }
+}


### PR DESCRIPTION
Due to the fact that I have to work with a large number of projects using Yii, and use of this plugin is a part of the deployment of the platform, waiting for the end of downloading all packages may take up to 40 minutes (bower uses github api and each time requests all pages with tags, eg package "bower-asset/angular" requests approximately 30 pages).

This service caches information about the packages and gives the already formed `json` file that accelerates project update.

You can specify your own cache server (http://source.0daysolution.ru/open-source/assagist) for each package type (npm or bower) using the config (default: `http://assagist.0daysolution.ru/packages/{bower,npm}/%package%`):

``` json
{
    "config": {
        "assagist-cache-bower-url": "http://example.com/packages/bower/%package%",
        "assagist-cache-npm-url" "http://example.com/packages/npm/%package%"
    }
}
```

Also you can enable/disable use of cache server (default: false):

``` json
{
    "config": {
        "assagist-cache-use": false
    }
}
```
