### PR TITLE
Implement bitbucket OAuth support (implemented in composer 1.2)

### DIFF
--- a/Repository/Vcs/GitBitbucketDriver.php
+++ b/Repository/Vcs/GitBitbucketDriver.php
@@ -41,6 +41,7 @@ class GitBitbucketDriver extends BaseGitBitbucketDriver
      */
     public function getComposerInformation($identifier)
     {
-        return BitbucketUtil::getComposerInformation($this->cache, $this->infoCache, $this->getScheme(), $this->repoConfig, $identifier, $this->owner, $this->repository, $this, 'getContents');
+        $method = method_exists($this, 'getContentsWithOAuthCredentials') ? 'getContentsWithOAuthCredentials' : 'getContents';
+        return BitbucketUtil::getComposerInformation($this->cache, $this->infoCache, $this->getScheme(), $this->repoConfig, $identifier, $this->owner, $this->repository, $this, $method);
     }
 }


### PR DESCRIPTION
In composer 1.2 support for OAuth authentication for bitbucket.org has been expanded.
This fix brings the same support to the composer asset plugin.
It's completely backwards compatible with composer versions before 1.2.