### PR TITLE
Ignore packages versions that are not supported by Composer

### DIFF
--- a/Repository/NpmRepository.php
+++ b/Repository/NpmRepository.php
@@ -16,6 +16,7 @@ use Composer\Package\CompletePackageInterface;
 use Composer\Package\Loader\ArrayLoader;
 use Composer\Repository\ArrayRepository;
 use Fxp\Composer\AssetPlugin\Exception\InvalidCreateRepositoryException;
+use UnexpectedValueException;
 
 /**
  * NPM repository.
@@ -128,9 +129,13 @@ class NpmRepository extends AbstractAssetsRepository
         $loader = new ArrayLoader();
 
         foreach ($packageConfigs as $version => $config) {
-            $config['version'] = $version;
-            $config = $this->assetType->getPackageConverter()->convert($config);
-            $packages[] = $loader->load($config);
+            try {
+                $config['version'] = $version;
+                $config = $this->assetType->getPackageConverter()->convert($config);
+                $packages[] = $loader->load($config);
+            } catch (UnexpectedValueException $e) {
+                $this->io->writeError("Composer Asset Plugin fails to parse version $version of $config[name], skipping it");
+            }
         }
 
         return $packages;


### PR DESCRIPTION
This should fix installation of `immutable` from NPM (https://www.npmjs.com/package/immutable) which appears to contain version `0.8.0-SNAPSHOT` which causes exception in Composer's version normalization.

There shouldn't be any major or even minor issues with this fix.
It will allow to install NPM packages, that contain appropriate version (while skipping versions like mentioned above) as well as still fail for packages that do not have any version that can be parsed by Composer.

Sorry for not adding any test case, I've tried, but failed to write correct one. Feel free to push more commits into this branch if needed, you should be able to do so.
