### PR TITLE
Feature/skip asset update

### DIFF
--- a/Repository/Vcs/GitDriver.php
+++ b/Repository/Vcs/GitDriver.php
@@ -12,6 +12,7 @@
 namespace Fxp\Composer\AssetPlugin\Repository\Vcs;
 
 use Composer\Cache;
+use Composer\IO\IOInterface;
 use Composer\Repository\Vcs\GitDriver as BaseGitDriver;
 
 /**
@@ -34,5 +35,27 @@ class GitDriver extends BaseGitDriver
         $resource = sprintf('%s:%s', escapeshellarg($identifier), $this->repoConfig['filename']);
 
         return ProcessUtil::getComposerInformation($this->cache, $this->infoCache, $this->repoConfig['asset-type'], $this->process, $identifier, $resource, sprintf('git show %s', $resource), sprintf('git log -1 --format=%%at %s', escapeshellarg($identifier)), $this->repoDir, '@');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function initialize()
+    {
+        /* @var AssetRepositoryManager $arm */
+        $arm = $this->repoConfig['asset-repository-manager'];
+
+        if (null !== ($skip = $arm->getConfig()->get('git-skip-update'))) {
+            $localUrl = $this->config->get('cache-vcs-dir') . '/' . preg_replace('{[^a-z0-9.]}i', '-', $this->url) . '/';
+
+            // check if local copy exists and if it is a git repository and that modification time is within threshold
+            if (is_dir($localUrl) && is_file($localUrl.'/config') && filemtime($localUrl) > strtotime('-'.$skip)) {
+                $this->io->write('(<comment>local</comment>) ', false, IOInterface::VERBOSE);
+                $this->url = $localUrl;
+            } else {
+                $this->io->write('(<info>remote</info>) ', false, IOInterface::VERBOSE);
+            }
+        }
+        parent::initialize();
     }
 }

--- a/Resources/doc/schema.md
+++ b/Resources/doc/schema.md
@@ -49,6 +49,16 @@ The plugin can override the main file definitions of the Bower packages. To over
 definitions specify the packages and their main file array as name/value pairs. For an example
 see the [usage informations](index.md#override-the-main-files-for-bower).
 
+##### config.fxp-asset.git-skip-update (root-only)
+
+The plugin can skip updating meta-data in git repositories for given amount of time, i.e. `6 hours`, `3 days` or `1 week`.
+
+    "config": {
+        "fxp-asset": {
+            "git-skip-update": "2 days"
+        }
+    }
+
 ### Mapping asset file to composer package
 
 ##### NPM mapping

--- a/Tests/Repository/Vcs/GitDriverTest.php
+++ b/Tests/Repository/Vcs/GitDriverTest.php
@@ -15,6 +15,7 @@ use Composer\Config;
 use Composer\IO\IOInterface;
 use Composer\Util\Filesystem;
 use Composer\Util\ProcessExecutor;
+use Fxp\Composer\AssetPlugin\Repository\AssetRepositoryManager;
 use Fxp\Composer\AssetPlugin\Repository\Vcs\GitDriver;
 
 /**
@@ -29,15 +30,34 @@ class GitDriverTest extends \PHPUnit_Framework_TestCase
      */
     private $config;
 
+    /**
+     * @var AssetRepositoryManager|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $assetRepositoryManager;
+
     public function setUp()
     {
+        $assetConfig = new \Fxp\Composer\AssetPlugin\Config\Config(array('git-skip-update' => '1 hour'));
+
+        /* @var AssetRepositoryManager|\PHPUnit_Framework_MockObject_MockObject $arm */
+        $this->assetRepositoryManager = $this->getMockBuilder(AssetRepositoryManager::class)->disableOriginalConstructor()->getMock();
+        $this->assetRepositoryManager->expects($this->any())
+            ->method('getConfig')
+            ->willReturn($assetConfig);
+
         $this->config = new Config();
         $this->config->merge(array(
             'config' => array(
                 'home' => sys_get_temp_dir().'/composer-test',
                 'cache-repo-dir' => sys_get_temp_dir().'/composer-test-cache',
+                'cache-vcs-dir' => sys_get_temp_dir().'/composer-test-cache',
             ),
         ));
+
+        // Mock for skip asset
+        $fs = new Filesystem();
+        $fs->ensureDirectoryExists(sys_get_temp_dir().'/composer-test-cache/https---github.com-fxpio-composer-asset-plugin.git');
+        file_put_contents(sys_get_temp_dir().'/composer-test-cache/https---github.com-fxpio-composer-asset-plugin.git/config', '');
     }
 
     public function tearDown()
@@ -71,6 +91,7 @@ class GitDriverTest extends \PHPUnit_Framework_TestCase
             'url' => $repoUrl,
             'asset-type' => $type,
             'filename' => $filename,
+            'asset-repository-manager' => $this->assetRepositoryManager,
         );
 
         $process = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
@@ -102,6 +123,65 @@ class GitDriverTest extends \PHPUnit_Framework_TestCase
      * @param string $type
      * @param string $filename
      */
+    public function testPublicRepositoryWithSkipUpdate($type, $filename)
+    {
+        $repoUrl = 'https://github.com/fxpio/composer-asset-plugin.git';
+        $identifier = '92bebbfdcde75ef2368317830e54b605bc938123';
+        $io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
+
+        $repoConfig = array(
+            'url' => $repoUrl,
+            'asset-type' => $type,
+            'filename' => $filename,
+            'asset-repository-manager' => $this->assetRepositoryManager,
+        );
+
+        $process = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
+        $process->expects($this->any())
+            ->method('splitLines')
+            ->will($this->returnValue(array()));
+        $process->expects($this->any())
+            ->method('execute')
+            ->will($this->returnCallback(function ($command, &$output = null) use ($identifier, $repoConfig) {
+                if ($command === sprintf('git show %s', sprintf('%s:%s', escapeshellarg($identifier), $repoConfig['filename']))) {
+                    $output = '{"name": "foo"}';
+                } elseif (false !== strpos($command, 'git log')) {
+                    $date = new \DateTime(null, new \DateTimeZone('UTC'));
+                    $output = $date->getTimestamp();
+                }
+
+                return 0;
+            }));
+
+        /* @var IOInterface $io */
+        /* @var ProcessExecutor $process */
+
+        $gitDriver1 = new GitDriver($repoConfig, $io, $this->config, $process, null);
+        $gitDriver1->initialize();
+
+        $gitDriver2 = new GitDriver($repoConfig, $io, $this->config, $process, null);
+        $gitDriver2->initialize();
+
+        $validEmpty = array(
+            '_nonexistent_package' => true,
+        );
+
+        $composer1 = $gitDriver1->getComposerInformation($identifier);
+        $composer2 = $gitDriver2->getComposerInformation($identifier);
+
+        $this->assertNotNull($composer1);
+        $this->assertNotNull($composer2);
+        $this->assertSame($composer1, $composer2);
+        $this->assertNotSame($validEmpty, $composer1);
+        $this->assertNotSame($validEmpty, $composer2);
+    }
+
+    /**
+     * @dataProvider getAssetTypes
+     *
+     * @param string $type
+     * @param string $filename
+     */
     public function testPublicRepositoryWithCodeCache($type, $filename)
     {
         $repoUrl = 'https://github.com/fxpio/composer-asset-plugin.git';
@@ -110,6 +190,7 @@ class GitDriverTest extends \PHPUnit_Framework_TestCase
             'url' => $repoUrl,
             'asset-type' => $type,
             'filename' => $filename,
+            'asset-repository-manager' => $this->assetRepositoryManager,
         );
         $io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
         $process = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();
@@ -156,6 +237,7 @@ class GitDriverTest extends \PHPUnit_Framework_TestCase
             'url' => $repoUrl,
             'asset-type' => $type,
             'filename' => $filename,
+            'asset-repository-manager' => $this->assetRepositoryManager,
         );
         $io = $this->getMockBuilder('Composer\IO\IOInterface')->getMock();
         $process = $this->getMockBuilder('Composer\Util\ProcessExecutor')->getMock();

--- a/Tests/Repository/Vcs/GitHubDriverTest.php
+++ b/Tests/Repository/Vcs/GitHubDriverTest.php
@@ -49,8 +49,13 @@ class GitHubDriverTest extends \PHPUnit_Framework_TestCase
             ),
         ));
 
+        $assetConfig = new \Fxp\Composer\AssetPlugin\Config\Config(array());
+
         $this->assetRepositoryManager = $this->getMockBuilder(AssetRepositoryManager::class)
             ->disableOriginalConstructor()->getMock();
+        $this->assetRepositoryManager->expects($this->any())
+            ->method('getConfig')
+            ->willReturn($assetConfig);
     }
 
     public function tearDown()


### PR DESCRIPTION
- fixes #251 

Testing:

```
composer global config repositories.foo vcs https://github.com/schmunk42/composer-asset-plugin.git
composer global require fxp/composer-asset-plugin:"dev-feature/skip-asset-update"
```

Note: `github-no-api` must be set to `true`

```
FXP_SKIP_ASSET_UPDATE="100 minutes" composer update -vv
```

Result:

🚀  4x faster (eg. with yii2-app-advanced ~10 seconds); after the first run

Currently creates an additional clone in the cache, I am open for discussion about the implementation. But in this way it should not affect existing installations at all.

CC: @cebe @samdark @motin @mikehaertl @tonydspaniard