### PR TITLE
Updated NpmRepository to skip broken versions

### DIFF
--- a/Repository/NpmRepository.php
+++ b/Repository/NpmRepository.php
@@ -158,8 +158,6 @@ class NpmRepository extends AbstractAssetsRepository
                 // Skip this version and hope that another one will be OK
                 $this->io->write("<warning>Skipped {$config['name']} version {$version}: {$exception->getMessage()}</warning>", IOInterface::VERBOSE);
                 continue;
-            } catch (\Exception $exception) {
-                throw $exception;
             }
         }
 

--- a/Repository/NpmRepository.php
+++ b/Repository/NpmRepository.php
@@ -12,6 +12,7 @@
 namespace Fxp\Composer\AssetPlugin\Repository;
 
 use Composer\DependencyResolver\Pool;
+use Composer\IO\IOInterface;
 use Composer\Package\CompletePackageInterface;
 use Composer\Package\Loader\ArrayLoader;
 use Composer\Repository\ArrayRepository;
@@ -155,6 +156,7 @@ class NpmRepository extends AbstractAssetsRepository
             } catch (\UnexpectedValueException $exception) {
                 // Most probably version constraint is broken.
                 // Skip this version and hope that another one will be OK
+                $this->io->write("<warning>Skipped {$config['name']} version {$version}: {$exception->getMessage()}</warning>", IOInterface::VERBOSE);
                 continue;
             } catch (\Exception $exception) {
                 throw $exception;

--- a/Repository/NpmRepository.php
+++ b/Repository/NpmRepository.php
@@ -147,10 +147,18 @@ class NpmRepository extends AbstractAssetsRepository
         $loader = new ArrayLoader();
 
         foreach ($packageConfigs as $version => $config) {
-            $config['version'] = $version;
-            $config = $this->assetType->getPackageConverter()->convert($config);
-            $config = $this->assetRepositoryManager->solveResolutions($config);
-            $packages[] = $loader->load($config);
+            try {
+                $config['version'] = $version;
+                $config = $this->assetType->getPackageConverter()->convert($config);
+                $config = $this->assetRepositoryManager->solveResolutions($config);
+                $packages[] = $loader->load($config);
+            } catch (\UnexpectedValueException $exception) {
+                // Most probably version constraint is broken.
+                // Skip this version and hope that another one will be OK
+                continue;
+            } catch (\Exception $exception) {
+                throw $exception;
+            }
         }
 
         return $packages;

--- a/Tests/Repository/NpmRepositoryTest.php
+++ b/Tests/Repository/NpmRepositoryTest.php
@@ -107,6 +107,62 @@ class NpmRepositoryTest extends AbstractAssetsRepositoryTest
         $this->assertCount(1, $this->rm->getRepositories());
     }
 
+    public function testWhatProvidesWithBrokenVersionConstraint()
+    {
+        $name = $this->getType().'-asset/foobar';
+        $rfs = $this->replaceRegistryRfsByMock();
+        $rfs->expects($this->any())
+            ->method('getContents')
+            ->will($this->returnValue(json_encode(array(
+                'repository' => array(
+                    'type' => 'vcs',
+                ),
+                'versions' => array(
+                    '1.0.0' => array(
+                        'name' => 'foobar',
+                        'version' => '0.0.1',
+                        'dependencies' => array(),
+                        'dist' => array(
+                            'shasum' => '1d408b3fdb76923b9543d96fb4c9dfd535d9cb5d',
+                            'tarball' => 'http://registry.tld/foobar/-/foobar-1.0.0.tgz',
+                        ),
+                    ),
+                    '1.0.1' => array(
+                        'name' => 'foobar',
+                        'version' => '0.0.1',
+                        'dependencies' => array(
+                            // This constraint is invalid. Whole version package version should be skipped.
+                            'library1' => '^1.2,,<2.0'
+                        ),
+                        'dist' => array(
+                            'shasum' => '1d408b3fdb76923b9543d96fb4c9acd535d9cb7a',
+                            'tarball' => 'http://registry.tld/foobar/-/foobar-1.0.1.tgz',
+                        ),
+                    ),
+                    '1.0.2' => array(
+                        'name' => 'foobar',
+                        'version' => '0.0.1',
+                        'dependencies' => array(
+                            'library1' => '^1.2,<2.0'
+                        ),
+                        'dist' => array(
+                            'shasum' => '1d408b3fdb76923b9543d96fb4c9acd535d9cb7a',
+                            'tarball' => 'http://registry.tld/foobar/-/foobar-1.0.1.tgz',
+                        ),
+                    ),
+                ),
+                'time' => array(
+                    '1.0.0' => '2016-09-20T13:48:47.730Z',
+                ),
+            ))));
+
+        $this->assertCount(0, $this->rm->getRepositories());
+        $this->assertCount(0, $this->registry->whatProvides($this->pool, $name));
+        $this->assertCount(0, $this->registry->whatProvides($this->pool, $name));
+        $this->assertCount(1, $this->rm->getRepositories());
+        $this->assertCount(2, $this->rm->getRepositories()[0]->getPackages());
+    }
+
     /**
      * @expectedException \Fxp\Composer\AssetPlugin\Exception\InvalidCreateRepositoryException
      * @expectedExceptionMessage "repository.url" parameter of "foobar"


### PR DESCRIPTION
Related to https://github.com/hiqdev/asset-packagist/issues/68

Some packages have dependencies with corrupted version constraints.
The change allows composer-asset-plugin to omit these versions.