### PR TITLE
Update bower registry URL

### DIFF
--- a/Repository/BowerRepository.php
+++ b/Repository/BowerRepository.php
@@ -31,7 +31,7 @@ class BowerRepository extends AbstractAssetsRepository
      */
     protected function getUrl()
     {
-        return 'https://bower.herokuapp.com/packages';
+        return 'https://registry.bower.io/packages';
     }
 
     /**


### PR DESCRIPTION
Currently `https://bower.herokuapp.com/packages` permanently redirects to `https://registry.bower.io/packages`, which is the new URL which should be used by bower according to https://github.com/bower/bower/issues/2484#issuecomment-335798883

fixes https://github.com/fxpio/composer-asset-plugin/issues/309
fixes https://github.com/yiisoft/yii2/issues/14987