### PR TITLE
Fix "Unknown downloader type: npm-signature" exception

### DIFF
--- a/Converter/NpmPackageUtil.php
+++ b/Converter/NpmPackageUtil.php
@@ -126,9 +126,22 @@ abstract class NpmPackageUtil
 
         if ('shasum' === $type) {
             $value[$type] = $url;
-        } else {
-            $value['type'] = 'tarball' === $type ? 'tar' : $type;
+        } elseif ('tarball' === $type) {
+            $value['type'] = 'tar';
+            $value['url'] = $url;
+        } elseif (in_array($type, self::getDownloaderTypes(), true)) {
+            $value['type'] = $type;
             $value['url'] = $url;
         }
+    }
+
+    /**
+     * Get downloader types in Composer.
+     *
+     * @return array
+     */
+    private static function getDownloaderTypes()
+    {
+        return array('git', 'svn', 'fossil', 'hg', 'perforce', 'zip', 'rar', 'tar', 'gzip', 'xz', 'phar', 'file', 'path');
     }
 }

--- a/Converter/SemverConverter.php
+++ b/Converter/SemverConverter.php
@@ -107,8 +107,8 @@ class SemverConverter implements VersionConverterInterface
         if (' - ' === $match) {
             $matches[$i - 1] = '>='.str_replace(array('*', 'x', 'X'), '0', $matches[$i - 1]);
 
-            if (false !== strpos($matches[$i + 1], '.') && strpos($matches[$i + 1], '*') === false
-                    && strpos($matches[$i + 1], 'x') === false && strpos($matches[$i + 1], 'X') === false) {
+            if (false !== strpos($matches[$i + 1], '.') && false === strpos($matches[$i + 1], '*')
+                    && false === strpos($matches[$i + 1], 'x') && false === strpos($matches[$i + 1], 'X')) {
                 $matches[$i] = ',<=';
             } else {
                 $matches[$i] = ',<';
@@ -177,14 +177,14 @@ class SemverConverter implements VersionConverterInterface
      */
     protected function matchRangeTokenStep4($i, $match, array &$matches, &$special, &$replace)
     {
-        if ($special === ',<~') {
+        if (',<~' === $special) {
             // Version range contains x in last place.
             $match .= (false === strpos($match, '.') ? '.x' : '');
             $version = explode('.', $match);
             $change = count($version) - 2;
             $version[$change] = (int) ($version[$change]) + 1;
             $match = str_replace(array('*', 'x', 'X'), '0', implode('.', $version));
-        } elseif (null === $special && $i === 0 && false === strpos($match, '.') && is_numeric($match)) {
+        } elseif (null === $special && 0 === $i && false === strpos($match, '.') && is_numeric($match)) {
             $match = isset($matches[$i + 1]) && (' - ' === $matches[$i + 1] || '-' === $matches[$i + 1])
                 ? $match
                 : '~'.$match;

--- a/Repository/Vcs/BitbucketUtil.php
+++ b/Repository/Vcs/BitbucketUtil.php
@@ -120,7 +120,7 @@ class BitbucketUtil
             $meth->setAccessible(true);
             $composer = $meth->invoke($driver, $resource);
 
-            if ($method !== 'getContents') {
+            if ('getContents' !== $method) {
                 $file = (array) JsonFile::parseJson((string) $composer, $resource);
                 $composer = empty($file) || !array_key_exists('data', $file)
                     ? false : $file['data'];

--- a/Repository/Vcs/GitHubDriver.php
+++ b/Repository/Vcs/GitHubDriver.php
@@ -95,7 +95,7 @@ class GitHubDriver extends AbstractGitHubDriver
     protected function parseComposerContent($resource)
     {
         $composer = (array) JsonFile::parseJson($this->getContents($resource));
-        if (empty($composer['content']) || $composer['encoding'] !== 'base64' || !($composer = base64_decode($composer['content']))) {
+        if (empty($composer['content']) || 'base64' !== $composer['encoding'] || !($composer = base64_decode($composer['content']))) {
             throw new \RuntimeException('Could not retrieve '.$this->repoConfig['filename'].' from '.$resource);
         }
 

--- a/Tests/Converter/NpmPackageConverterTest.php
+++ b/Tests/Converter/NpmPackageConverterTest.php
@@ -189,9 +189,13 @@ class NpmPackageConverterTest extends AbstractPackageConverterTest
     {
         return array(
             array(array('type' => null), array()),
-            array(array('type' => 'http://example.com'), array('type' => 'type', 'url' => 'https://example.com')),
+            array(array('foo' => 'http://example.com'), array()), // unknown downloader type
+            array(array('gzip' => 'http://example.com'), array('type' => 'gzip', 'url' => 'https://example.com')),
             array(array('tarball' => 'http://example.com'), array('type' => 'tar', 'url' => 'https://example.com')),
-            array(array('shasum' => 'abcdef0123456789abcdef0123456789abcdef01'), array('shasum' => 'abcdef0123456789abcdef0123456789abcdef01')),
+            array(
+                array('shasum' => 'abcdef0123456789abcdef0123456789abcdef01'),
+                array('shasum' => 'abcdef0123456789abcdef0123456789abcdef01'),
+            ),
         );
     }
 


### PR DESCRIPTION
Dist entry resolution is now restricted to downloader types
known by composer. Effectively this means that composer-asset-plugin
will skip all dist entries that link to custom vendor protocol
implementations, e.g. npm-signature.

Fixes #321

Replaces #323 