### PR TITLE
Added licenses conversion for NPM packages

### DIFF
--- a/Converter/NpmPackageConverter.php
+++ b/Converter/NpmPackageConverter.php
@@ -39,7 +39,9 @@ class NpmPackageConverter extends AbstractPackageConverter
             'description' => 'description',
             'keywords' => 'keywords',
             'homepage' => 'homepage',
-            'license' => 'license',
+            'license' => array('license', function ($value) {
+                return NpmPackageUtil::convertLicenses($value);
+            }),
             'time' => 'time',
             'author' => array('authors', function ($value) {
                 return NpmPackageUtil::convertAuthor($value);

--- a/Converter/NpmPackageUtil.php
+++ b/Converter/NpmPackageUtil.php
@@ -51,6 +51,35 @@ abstract class NpmPackageUtil
     }
 
     /**
+     * Convert the npm licenses list.
+     *
+     * @param array|string $licenses The npm package licenses list
+     *
+     * @return array|string
+     */
+    public static function convertLicenses($licenses)
+    {
+        if (!is_array($licenses)) {
+            return $licenses;
+        }
+
+        $result = [];
+        foreach ($licenses as $license) {
+            if (is_array($license)) {
+                if (!empty($license['type'])) {
+                    $result[] = $license['type'];
+                } elseif (!empty($license['name'])) {
+                    $result[] = $license['name'];
+                }
+            } else {
+                $result[] = $license;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
      * Convert the author section.
      *
      * @param string|null $value The current value


### PR DESCRIPTION
Thanks to @roygoldman it turned out that older NPM repositories may have used objects when defining licences.

Please see more detailed explanation at https://github.com/hiqdev/asset-packagist/issues/87

And example of package.json with such licenses:

https://github.com/geraintluff/tv4/blob/master/package.json#L24-L33