### PR TITLE
Add "provide" information to composer.json

### DIFF
--- a/Converter/AbstractPackageConverter.php
+++ b/Converter/AbstractPackageConverter.php
@@ -75,6 +75,11 @@ abstract class AbstractPackageConverter implements PackageConverterInterface
             $this->convertExtraKey($asset, $assetKey, $composer, $composerKey);
         }
 
+        $provide = str_replace($this->assetType->getComposerVendorName() . '/' , '', $composer['name']);
+        $composer['provide'] = array(
+            "{$provide}/{$provide}-implementation" => $composer['version']
+        );
+
         return $composer;
     }
 

--- a/Resources/doc/schema.md
+++ b/Resources/doc/schema.md
@@ -100,7 +100,7 @@ The `package.json` of asset repository is automatically converted to a Complete 
 | `not used`           | support                               |
 | `not used`           | conflict                              |
 | `not used`           | replace                               |
-| `not used`           | provide                               |
+| `not used`           | provide (`{name}/{name}-implementation => {version}`)                                |
 | `not used`           | suggest                               |
 | `not used`           | autoload                              |
 | `not used`           | autoload-dev                          |
@@ -133,7 +133,7 @@ The `bower.json` of asset repository is automatically converted to a Complete Pa
 | `not used`           | support                               |
 | `not used`           | conflict                              |
 | `not used`           | replace                               |
-| `not used`           | provide                               |
+| `not used`           | provide (`{name}/{name}-implementation => {version}`)                                |
 | `not used`           | suggest                               |
 | `not used`           | autoload                              |
 | `not used`           | autoload-dev                          |

--- a/Tests/Converter/BowerPackageConverterTest.php
+++ b/Tests/Converter/BowerPackageConverterTest.php
@@ -85,6 +85,11 @@ final class BowerPackageConverterTest extends AbstractPackageConverterTest
         $this->assertArrayHasKey('bin', $composer);
         $this->assertSame($this->asset['bin'], $composer['bin']);
 
+        $this->assertArrayHasKey('provide', $composer);
+        $this->assertInternalType('array', $composer['provide']);
+        $this->assertArrayHasKey("{$this->asset['name']}/{$this->asset['name']}-implementation", $composer['provide']);
+        $this->assertEquals($composer['version'], $composer['provide']["{$this->asset['name']}/{$this->asset['name']}-implementation"]);
+
         $this->assertArrayHasKey('extra', $composer);
 
         $this->assertArrayHasKey('bower-asset-main', $composer['extra']);
@@ -102,7 +107,6 @@ final class BowerPackageConverterTest extends AbstractPackageConverterTest
         $this->assertArrayNotHasKey('support', $composer);
         $this->assertArrayNotHasKey('conflict', $composer);
         $this->assertArrayNotHasKey('replace', $composer);
-        $this->assertArrayNotHasKey('provide', $composer);
         $this->assertArrayNotHasKey('suggest', $composer);
         $this->assertArrayNotHasKey('autoload', $composer);
         $this->assertArrayNotHasKey('autoload-dev', $composer);

--- a/Tests/Converter/NpmPackageConverterTest.php
+++ b/Tests/Converter/NpmPackageConverterTest.php
@@ -94,6 +94,11 @@ final class NpmPackageConverterTest extends AbstractPackageConverterTest
         $this->assertInternalType('array', $composer['bin']);
         $this->assertSame($this->asset['bin'], $composer['bin'][0]);
 
+        $this->assertArrayHasKey('provide', $composer);
+        $this->assertInternalType('array', $composer['provide']);
+        $this->assertArrayHasKey("{$this->asset['name']}/{$this->asset['name']}-implementation", $composer['provide']);
+        $this->assertEquals($composer['version'], $composer['provide']["{$this->asset['name']}/{$this->asset['name']}-implementation"]);
+
         $this->assertArrayHasKey('extra', $composer);
 
         $this->assertArrayHasKey('npm-asset-bugs', $composer['extra']);
@@ -151,7 +156,6 @@ final class NpmPackageConverterTest extends AbstractPackageConverterTest
         $this->assertArrayNotHasKey('support', $composer);
         $this->assertArrayNotHasKey('conflict', $composer);
         $this->assertArrayNotHasKey('replace', $composer);
-        $this->assertArrayNotHasKey('provide', $composer);
         $this->assertArrayNotHasKey('suggest', $composer);
         $this->assertArrayNotHasKey('autoload', $composer);
         $this->assertArrayNotHasKey('autoload-dev', $composer);


### PR DESCRIPTION
Hi, first, thanks for this excellent library. Without this, I guess https://asset-packagist.org/ would not exist. :) 90% of the time I am working with [Drupal](http://drupal.org), I am not sure whether you have heard about Drupal before. There is a problem that my colleagues and I are trying to solve, and I guess we are not the only one who is facing this problem day by day in the Drupal community. I also think we are not the only one with this problem in the PHP world, other frameworks, like Symfony, Yii could have the same problem.

### Intro
In Drupal, we have smaller building blocks (libraries) called "modules" and "themes". A module could provide additional functionalities if it is enabled. A theme could change the look and feel of a site. Since Drupal 8, Drupal uses Composer to [manage dependencies](https://github.com/drupal/drupal/blob/8.8.x/composer.json). Every Drupal module and theme could define its dependencies in its composer.json and Composer resolves them when a module or theme get installed. Drupal also has its ["own Packagist"](https://www.drupal.org/docs/develop/using-composer/using-packagesdrupalorg) for Drupal components.
A Drupal module/theme could have external Javascript dependencies that should be installed by Composer. At this moment, the majority of the Drupal community has a preferred way to install JS dependencies. They register the asset-packagist in a _Drupal installation's root composer.json_ and pulls dependencies from there although there are other possible options to install a JS dependency, like using the VCS or the path repository providers, etc.

### Problem
We have a module that uses the [Swagger UI library](https://github.com/swagger-api/swagger-ui) to render API specification in Drupal: https://github.com/Pronovix/swagger_ui_formatter. This module does not work if the library is not installed. We added sanity checks that validate in Drupal whether the library is available although it would be great if we could add the Swagger UI as an actual (Composer) dependency to the module.

Currently, we only have the following option: Add `npm-asset/swagger-ui` or `bower-asset/swagger-ui` as a dependency to our module. This could ensure when the module gets installed, the Swagger UI library also gets installed with it, but this solution could cause other problems:
* This approach only works, if the asset-packagist repo is registered in the Drupal installation's root composer.json. The module can not register the asset-packagist repository because it has to be registered in the root composer.json. If the repository has not been registered, the installation fails with some mystical dependency error: `The requested package bower-asset/swagger-ui could not be found in any version, there may be a typo in the package name.` If someone did not read our module's install steps that detail the asset-packagist repo has to be registered first (developers always read documentation ;P) then the developer stuck with the installation process and probably s/he will send a new bug report to our GH issue queue.
* If we add `bower-asset/swagger-ui` to our module's requirement, it could also happen that someone installs another module that requires `npm-asset/swagger-ui`. What happens? Best case, the same JS library gets installed to the same place twice, the later dependency overrides the files installed by the earlier one. Worst case, dependency hell.
* It could also happen that someone already installed the Swagger UI directly from its Github repo with the VCS provider. Should the module install another version from the same library from a different source? Well, it should not.

### Proposed solution

If composer.json-s generated by asset-packagist would contain information about virtual packages that a certain JS package is compatible with, we could depend on the virtual package in Drupal modules/themes and we would not need to care about how and where a JS dependency gets installed.

This PR adds the following information to the `bower-asset/swagger-ui`'s composer.json:

```json
            "provide": {
                "swagger-ui/swagger-ui-implementation": "v3.22.3"
            },
```
With this information in place, we could add:

```json
  "require": {
      "swagger-ui/swagger-ui-implementation": "^3.2",
      "symfony/dom-crawler": "~3.4|~4.0"
  }
```