### PR TITLE
Added `url` repository type support

### DIFF
--- a/Assets.php
+++ b/Assets.php
@@ -57,6 +57,7 @@ class Assets
         'hg' => 'Fxp\Composer\AssetPlugin\Repository\AssetVcsRepository',
         'perforce' => 'Fxp\Composer\AssetPlugin\Repository\AssetVcsRepository',
         'svn' => 'Fxp\Composer\AssetPlugin\Repository\AssetVcsRepository',
+        'url' => 'Fxp\Composer\AssetPlugin\Repository\AssetVcsRepository',
     );
 
     /**
@@ -69,6 +70,7 @@ class Assets
         'hg-bitbucket' => 'Fxp\Composer\AssetPlugin\Repository\Vcs\HgBitbucketDriver',
         'hg' => 'Fxp\Composer\AssetPlugin\Repository\Vcs\HgDriver',
         'perforce' => 'Fxp\Composer\AssetPlugin\Repository\Vcs\PerforceDriver',
+        'url' => 'Fxp\Composer\AssetPlugin\Repository\Vcs\GitDriver',
         // svn must be last because identifying a subversion server for sure is practically impossible
         'svn' => 'Fxp\Composer\AssetPlugin\Repository\Vcs\SvnDriver',
     );

--- a/Tests/AssetsTest.php
+++ b/Tests/AssetsTest.php
@@ -49,6 +49,7 @@ final class AssetsTest extends \PHPUnit\Framework\TestCase
             'hg',
             'perforce',
             'svn',
+            'url',
         ), array_keys(Assets::getVcsRepositoryDrivers()));
     }
 
@@ -61,6 +62,7 @@ final class AssetsTest extends \PHPUnit\Framework\TestCase
             'hg-bitbucket',
             'hg',
             'perforce',
+            'url',
             'svn',
         ), array_keys(Assets::getVcsDrivers()));
     }


### PR DESCRIPTION
Hi, François!

We've got [an issue](https://github.com/hiqdev/asset-packagist/issues/101) that `npm/ascli` package does not get fetched.

The reason is that they set [`repository.type = url` ](https://github.com/dcodeIO/ascli/blob/5972ea9baf6939fc0f47a3435cedd66bc6f66fe1/package.json#L7) that is not supported. I haven't found any specification on allowed repository type values, but if you think this change is acceptable – please, merge it.